### PR TITLE
Fix ReferenceError

### DIFF
--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -4,7 +4,6 @@ var AWS = require('aws-sdk');
 function CloudwatchBackend(startupTime, config, emitter){
   var self = this;
 
-  config.cloudwatch.region = config.cloudwatch.region ? amazon[config.cloudwatch.region] : null;
   this.config = config.cloudwatch || {};
   this.cloudwatch = new AWS.CloudWatch(config.cloudwatch);
 


### PR DESCRIPTION
While using this backend, the following error occurred:

`ReferenceError: statString is not defined`

The variables causing the error were `statString` and `numStats` which are unused, so the solution was to remove them. I also removed some trailing whitespaces.
