### PR TITLE
Metrics whitelist feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,23 @@ For example, sending StatsD the following
 
 is will produce the equivalent to the former configuration example. Note that both will be suppressed if overriden as in the former configuration example.
 
+## Whitelisting Metrics
+
+Using cloudwatch will incur a cost for each metric sent. In order to control your costs, you can optionally whitelist (by full metric name) those metrics sent to cloudwatch. For example:
+
+    {
+        backends: [ "aws-cloudwatch-statsd-backend" ],
+        cloudwatch: 
+        {
+            accessKeyId: 'YOUR_ACCESS_KEY_ID', 
+            secretAccessKey: 'YOUR_SECRET_ACCESS_KEY', 
+            region: 'YOUR_REGION',
+            whitelist: ['YOUR_FULL_METRIC_NAME']
+        }
+    }
+
+The above configuration would only sent the metric named 'YOUR_FULL_METRIC_NAME' to cloudwatch. As this is an array, you can specify multiple metrics. This is useful if you are using multiple backends e.g. mysql backend and want to send some metrics cloudwatch (due to the associated cost) and all the metrics together to another backend. It is also useful if you want to limit the metrics you use in cloudwatch to those that raise alarms as part of your wider AWS hosted system.
+
 ## Tutorial
 
 This project was launched with a following [blog post/tutorial](http://blog.simpletask.se/post/aggregating-monitoring-statistics-for-aws-cloudwatch) describing the implementation chain from log4net to Cloudwatch on a Windows system.

--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -38,6 +38,11 @@ console.log(new Date(timestamp*1000).toISOString());
   for (key in counters) {
 	  if (key.indexOf('statsd.') == 0)
 		  continue;
+
+        if(this.config.whitelist && this.config.whitelist.length >0 && this.config.whitelist.indexOf(key) == -1) {
+                console.log("Key (counter) "+key+" not in whitelist");
+                continue;
+        }
 	 
 	 names = this.config.processKeyForNamespace ? this.processKey(key) : {};
 	 var namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
@@ -60,6 +65,12 @@ console.log(new Date(timestamp*1000).toISOString());
 
   for (key in timers) {
     if (timers[key].length > 0) {
+
+        if(this.config.whitelist && this.config.whitelist.length >0 && this.config.whitelist.indexOf(key) == -1) {
+                console.log("Key (counter) "+key+" not in whitelist");
+                continue;
+        }
+
       var values = timers[key].sort(function (a,b) { return a-b; });
       var count = values.length;
       var min = values[0];
@@ -108,6 +119,12 @@ console.log(new Date(timestamp*1000).toISOString());
   }
 
   for (key in gauges) {
+
+        if(this.config.whitelist && this.config.whitelist.length >0 && this.config.whitelist.indexOf(key) == -1) {
+                console.log("Key (counter) "+key+" not in whitelist");
+                continue;
+        }
+
 	 names = this.config.processKeyForNamespace ? this.processKey(key) : {};
 	 var namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
 	 var metricName = this.config.metricName || names.metricName || key;
@@ -128,6 +145,12 @@ console.log(new Date(timestamp*1000).toISOString());
   }
 
   for (key in sets) {
+
+        if(this.config.whitelist && this.config.whitelist.length >0 && this.config.whitelist.indexOf(key) == -1) {
+                console.log("Key (counter) "+key+" not in whitelist");
+                continue;
+        }
+  	
 	 names = this.config.processKeyForNamespace ? this.processKey(key) : {};
 	 var namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
 	 var metricName = this.config.metricName || names.metricName || key;


### PR DESCRIPTION
I have implemented a configuration feature that allows users to specify a whitelist of metrics they with to forward on to cloudwatch. If the metric key does not appear in the whitelist config array, then that metric is skipped from being forwarded to cloudwatch. 

This feature is very useful to us as it allows us to have multiple backends, of which only those metrics we need to raise alarms/perform autoscaling based on a specific limit set of metrics. Of course, this allows us to keep costs down. We have over 100+ additional metrics we want to pass through our statsd instance; the costs of passing these metrics to cloudwatch would very quickly mount up, but we do want them forwarded to our mysql backend.

Anyway, have a look at the pull request and let me know if this is something you are interested in integrating with your project. It would be nice if we didn't have to maintain our own fork for this, and that it was part of the root project.

Cheers!
Jalf
