### PR TITLE
add support for IAM roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,20 @@ Using cloudwatch will incur a cost for each metric sent. In order to control you
 
 The above configuration would only sent the metric named 'YOUR_FULL_METRIC_NAME' to cloudwatch. As this is an array, you can specify multiple metrics. This is useful if you are using multiple backends e.g. mysql backend and want to send some metrics cloudwatch (due to the associated cost) and all the metrics together to another backend. It is also useful if you want to limit the metrics you use in cloudwatch to those that raise alarms as part of your wider AWS hosted system.
 
+## Using AWS Roles to obtain credentials
+
+A preferable approach to obtaining account credentials is instead to query the Metadata Service to obtain IAM security credentials for a given role. If iamRole is set to 'any' then any available credentials found on the metadata service will instead be used. For example:
+
+    {
+        backends: [ "aws-cloudwatch-statsd-backend" ],
+        cloudwatch:
+        {
+            iamRole: 'YOUR_ROLE_NAME',
+            region: 'YOUR_REGION',
+            whitelist: ['YOUR_FULL_METRIC_NAME']
+        }
+    }
+
 ## Tutorial
 
 This project was launched with a following [blog post/tutorial](http://blog.simpletask.se/post/aggregating-monitoring-statistics-for-aws-cloudwatch) describing the implementation chain from log4net to Cloudwatch on a Windows system.

--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -5,10 +5,37 @@ function CloudwatchBackend(startupTime, config, emitter){
   var self = this;
 
   this.config = config.cloudwatch || {};
-  this.cloudwatch = new AWS.CloudWatch(config.cloudwatch);
+  AWS.config = this.config;
 
-  // attach
-  emitter.on('flush', function(timestamp, metrics) { self.flush(timestamp, metrics); });
+  function setEmitter() {
+    self.cloudwatch = new AWS.CloudWatch(AWS.config);
+    emitter.on('flush', function(timestamp, metrics) { self.flush(timestamp, metrics); });
+  }
+
+  // if iamRole is set attempt to fetch credentials from the Metadata Service
+  if(this.config.iamRole) {
+    if (this.config.iamRole == 'any') {
+      // If the iamRole is set to any, then attempt to fetch any available credentials
+      ms = new AWS.EC2MetadataCredentials();
+      ms.refresh(function(err) {
+        if(err) { console.log('Failed to fetch IAM role credentials: '+err); }
+        AWS.config.credentials = ms;
+        setEmitter();
+      });
+    } else {
+      // however if it's set to specify a role, query it specifically.
+      ms = new AWS.MetadataService();
+      ms.request('/latest/meta-data/iam/security-credentials/'+this.config.iamRole, function(err, rdata) {
+        var data = JSON.parse(rdata);
+
+        if(err) { console.log('Failed to fetch IAM role credentials: '+err); }
+        AWS.config.credentials = new AWS.Credentials(data.AccessKeyId, data.SecretAccessKey, data.Token);
+        setEmitter();
+      });
+    }
+  } else {
+    setEmitter();
+  }
 };
 
 CloudwatchBackend.prototype.processKey = function(key) {


### PR DESCRIPTION
One of the issues we've had is that we do not want to pass around credentials, and the best way to securely deliver that function without passing credentials is to use IAM roles which are assigned to the instance. I've hacked in support for looking up credentials against the IAM metadata and I have tested it for a short period on my current instances. The role needs granting appropriate cloudwatch access and the role name passed in via the cloudwatch configuration stanza, from there it should just work as expected.

Thanks.