### PR TITLE
add multi-region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,40 @@ A preferable approach to obtaining account credentials is instead to query the M
         }
     }
 
+## Multi-region support
+
+If you wish to send cloudwatch metrics to multiple regions at once, instead of 
+
+    {
+        backends: [ "aws-cloudwatch-statsd-backend" ],
+        cloudwatch: 
+        {
+            accessKeyId: 'YOUR_ACCESS_KEY_ID', 
+            secretAccessKey:'YOUR_SECRET_ACCESS_KEY', 
+            region:"YOUR_REGION"
+        }
+    }
+    
+you can use the `instances` key under `cloudwatch` to configure a list of configurations.
+
+    {
+        backends: ["aws-cloudwatch-statsd-backend"],
+        cloudwatch: {
+            instances: [{
+                accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+                region: "YOUR_REGION_1",
+                whitelist: ['YOUR_FULL_METRIC_NAME1']
+            }, {
+                accessKeyId: 'YOUR_ACCESS_KEY_ID',
+                secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
+                region: "YOUR_REGION_2",
+                whitelist: ['YOUR_FULL_METRIC_NAME2']
+            }]
+        }
+    }
+
+
 ## Tutorial
 
 This project was launched with a following [blog post/tutorial](http://blog.simpletask.se/post/aggregating-monitoring-statistics-for-aws-cloudwatch) describing the implementation chain from log4net to Cloudwatch on a Windows system.

--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -4,11 +4,11 @@ var AWS = require('aws-sdk');
 function CloudwatchBackend(startupTime, config, emitter){
   var self = this;
 
-  this.config = config.cloudwatch || {};
+  this.config = config || {};
   AWS.config = this.config;
 
   function setEmitter() {
-    self.cloudwatch = new AWS.CloudWatch(AWS.config);
+    self.cloudwatch = new AWS.CloudWatch(self.config);
     emitter.on('flush', function(timestamp, metrics) { self.flush(timestamp, metrics); });
   }
 
@@ -19,7 +19,7 @@ function CloudwatchBackend(startupTime, config, emitter){
       ms = new AWS.EC2MetadataCredentials();
       ms.refresh(function(err) {
         if(err) { console.log('Failed to fetch IAM role credentials: '+err); }
-        AWS.config.credentials = ms;
+        self.config.credentials = ms;
         setEmitter();
       });
     } else {
@@ -29,7 +29,7 @@ function CloudwatchBackend(startupTime, config, emitter){
         var data = JSON.parse(rdata);
 
         if(err) { console.log('Failed to fetch IAM role credentials: '+err); }
-        AWS.config.credentials = new AWS.Credentials(data.AccessKeyId, data.SecretAccessKey, data.Token);
+        self.config.credentials = new AWS.Credentials(data.AccessKeyId, data.SecretAccessKey, data.Token);
         setEmitter();
       });
     }
@@ -194,6 +194,12 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
 };
 
 exports.init = function(startupTime, config, events) {
-  var instance = new CloudwatchBackend(startupTime, config, events);
+  var cloudwatch = config.cloudwatch || {};
+  var instances = cloudwatch.instances || [cloudwatch];
+  for (key in instances) {
+    instanceConfig = instances[key];
+    console.log("Starting cloudwatch reporter instance in region:", instanceConfig.region);
+    var instance = new CloudwatchBackend(startupTime, instanceConfig, events);
+  }
   return true;
 };


### PR DESCRIPTION
* adds multi-region support by allowing a list of cloudwatch configurations
* existing functionality stays as-is, but if the `instances` key exists under `cloudwatch`, it takes precedence over the configuration inside `cloudwatch` (see the README update for an example)