### PR TITLE
Optimized sending of data to cloudwatch

### DIFF
--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -50,6 +50,13 @@ CloudwatchBackend.prototype.processKey = function(key) {
 CloudwatchBackend.prototype.isBlacklisted = function(key) {
 
   var blacklisted = false;
+
+  // First check if key is whitelisted
+  if (this.config.whitelist && this.config.whitelist.length > 0 && this.config.whitelist.indexOf(key) >= 0) {
+      // console.log("Key (counter) " + key + " is whitelisted");
+      return false;
+  }
+
   if (this.config.blacklist && this.config.blacklist.length > 0) {
     for (var i = 0; i < this.config.blacklist.length; i++) {
       if (key.indexOf(this.config.blacklist[i]) >= 0) {
@@ -112,11 +119,6 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
     if (key.indexOf('statsd.') == 0)
       continue;
 
-    if (this.config.whitelist && this.config.whitelist.length > 0 && this.config.whitelist.indexOf(key) == -1) {
-      // console.log("Key (counter) " + key + " not in whitelist");
-      continue;
-    }
-
     if (this.isBlacklisted(key)) {
       continue;
     }
@@ -139,11 +141,6 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
   var currentTimerMetrics = [];
   for (key in timers) {
     if (timers[key].length > 0) {
-
-      if (this.config.whitelist && this.config.whitelist.length > 0 && this.config.whitelist.indexOf(key) == -1) {
-        // console.log("Key (counter) " + key + " not in whitelist");
-        continue;
-      }
 
       if (this.isBlacklisted(key)) {
         continue;
@@ -196,11 +193,6 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
   var currentGaugeMetrics = [];
   for (key in gauges) {
 
-    if (this.config.whitelist && this.config.whitelist.length > 0 && this.config.whitelist.indexOf(key) == -1) {
-      // console.log("Key (counter) " + key + " not in whitelist");
-      continue;
-    }
-
     if (this.isBlacklisted(key)) {
       continue;
     }
@@ -222,11 +214,6 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
   // put all currently accumulated set metrics into an array
   var currentSetMetrics = [];
   for (key in sets) {
-
-    if (this.config.whitelist && this.config.whitelist.length > 0 && this.config.whitelist.indexOf(key) == -1) {
-      // console.log("Key (counter) " + key + " not in whitelist");
-      continue;
-    }
 
     if (this.isBlacklisted(key)) {
       continue;

--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -47,6 +47,41 @@ CloudwatchBackend.prototype.processKey = function(key) {
   };
 };
 
+CloudwatchBackend.prototype.chunk = function(arr, chunkSize) {
+
+  var groups = [],
+    i;
+  for (i = 0; i < arr.length; i += chunkSize) {
+    groups.push(arr.slice(i, i + chunkSize));
+  }
+  return groups;
+};
+
+CloudwatchBackend.prototype.batchSend = function(currentMetricsBatch, namespace) {
+
+  // send off the array (instead of one at a time)
+  if (currentMetricsBatch.length > 0) {
+
+    // Chunk into groups of 20
+    var chunkedGroups = this.chunk(currentMetricsBatch, 20);
+
+    for (var i = 0, len = chunkedGroups.length; i < len; i++) {
+      this.cloudwatch.putMetricData({
+        MetricData: chunkedGroups[i],
+        Namespace: namespace
+      }, function(err, data) {
+        if (err) {
+          // log an error
+          console.log(util.inspect(err));
+        } else {
+          // Success
+          // console.log(util.inspect(data));
+        }
+      });
+    }
+  }
+};
+
 CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
 
   console.log('Flushing metrics at ' + new Date(timestamp * 1000).toISOString());
@@ -80,21 +115,7 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
     });
   }
 
-  // send off the array (instead of one at a time)
-  if (currentCounterMetrics.length > 0) {
-    this.cloudwatch.putMetricData({
-      MetricData: currentCounterMetrics,
-      Namespace: namespace
-    }, function(err, data) {
-      if (err) {
-        // log an error
-        console.log(util.inspect(err));
-      } else {
-        // Success
-        // console.log(util.inspect(data));
-      }
-    });
-  }
+  this.batchSend(currentCounterMetrics, namespace);
 
   // put all currently accumulated timer metrics into an array
   var currentTimerMetrics = [];
@@ -147,21 +168,7 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
     }
   }
 
-  // send off the array (instead of one at a time)  
-  if (currentTimerMetrics.length > 0) {
-    this.cloudwatch.putMetricData({
-      MetricData: currentTimerMetrics,
-      Namespace: namespace
-    }, function(err, data) {
-      if (err) {
-        // log an error
-        console.log(util.inspect(err));
-      } else {
-        // Success
-        // console.log(util.inspect(data));
-      }
-    });
-  }
+  this.batchSend(currentTimerMetrics, namespace);
 
   // put all currently accumulated gauge metrics into an array
   var currentGaugeMetrics = [];
@@ -184,21 +191,7 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
     });
   }
 
-  // send off the array (instead of one at a time)
-  if (currentGaugeMetrics.length > 0) {
-    this.cloudwatch.putMetricData({
-      MetricData: currentGaugeMetrics,
-      Namespace: namespace
-    }, function(err, data) {
-      if (err) {
-        // log an error
-        console.log(util.inspect(err));
-      } else {
-        // Success
-        // console.log(util.inspect(data));
-      }
-    });
-  }
+  this.batchSend(currentGaugeMetrics, namespace);
 
   // put all currently accumulated set metrics into an array
   var currentSetMetrics = [];
@@ -221,21 +214,7 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
     });
   }
 
-  // send off the array (instead of one at a time)
-  if (currentSetMetrics.length > 0) {
-    this.cloudwatch.putMetricData({
-      MetricData: currentSetMetrics,
-      Namespace: namespace
-    }, function(err, data) {
-      if (err) {
-        // log an error
-        console.log(util.inspect(err));
-      } else {
-        // Success
-        // console.log(util.inspect(data));
-      }
-    });
-  }
+  this.batchSend(currentSetMetrics, namespace);
 };
 
 exports.init = function(startupTime, config, events) {

--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -58,6 +58,7 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
 
   // put all currently accumulated counter metrics into an array
   var currentCounterMetrics = [];
+  var currentNamespace = "AwsCloudWatchStatsdBackend";
   for (key in counters) {
     if (key.indexOf('statsd.') == 0)
       continue;
@@ -68,7 +69,7 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
     }
 
     var names = this.config.processKeyForNamespace ? this.processKey(key) : {};
-    var namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
+    namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
     var metricName = this.config.metricName || names.metricName || key;
 
     currentCounterMetrics.push({
@@ -127,7 +128,7 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
       mean = sum / count;
 
       var names = this.config.processKeyForNamespace ? this.processKey(key) : {};
-      var namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
+      namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
       var metricName = this.config.metricName || names.metricName || key;
 
       currentTimerMetrics.push({
@@ -168,7 +169,7 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
     }
 
     var names = this.config.processKeyForNamespace ? this.processKey(key) : {};
-    var namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
+    namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
     var metricName = this.config.metricName || names.metricName || key;
 
     currentGaugeMetrics.push({
@@ -203,7 +204,7 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
     }
 
     var names = this.config.processKeyForNamespace ? this.processKey(key) : {};
-    var namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
+    namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
     var metricName = this.config.metricName || names.metricName || key;
 
     currentSetMetrics.push({

--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -113,7 +113,7 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
       continue;
 
     if (this.config.whitelist && this.config.whitelist.length > 0 && this.config.whitelist.indexOf(key) == -1) {
-      console.log("Key (counter) " + key + " not in whitelist");
+      // console.log("Key (counter) " + key + " not in whitelist");
       continue;
     }
 
@@ -141,7 +141,7 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
     if (timers[key].length > 0) {
 
       if (this.config.whitelist && this.config.whitelist.length > 0 && this.config.whitelist.indexOf(key) == -1) {
-        console.log("Key (counter) " + key + " not in whitelist");
+        // console.log("Key (counter) " + key + " not in whitelist");
         continue;
       }
 
@@ -197,7 +197,7 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
   for (key in gauges) {
 
     if (this.config.whitelist && this.config.whitelist.length > 0 && this.config.whitelist.indexOf(key) == -1) {
-      console.log("Key (counter) " + key + " not in whitelist");
+      // console.log("Key (counter) " + key + " not in whitelist");
       continue;
     }
 
@@ -224,7 +224,7 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
   for (key in sets) {
 
     if (this.config.whitelist && this.config.whitelist.length > 0 && this.config.whitelist.indexOf(key) == -1) {
-      console.log("Key (counter) " + key + " not in whitelist");
+      // console.log("Key (counter) " + key + " not in whitelist");
       continue;
     }
 

--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -49,12 +49,16 @@ CloudwatchBackend.prototype.processKey = function(key) {
 
 CloudwatchBackend.prototype.isBlacklisted = function(key) {
 
-  if (this.config.blacklist && this.config.blacklist.length > 0 && this.config.blacklist.indexOf(key) !== -1) {
-    // console.log("Key (counter) " + key + " is blacklisted");
-    return true;
+  var blacklisted = false;
+  if (this.config.blacklist && this.config.blacklist.length > 0) {
+    for (var i = 0; i < this.config.blacklist.length; i++) {
+      if (key.indexOf(this.config.blacklist[i]) >= 0) {
+        blacklisted = true;
+        break;
+      }
+    }
   }
-
-  return false;
+  return blacklisted;
 };
 
 CloudwatchBackend.prototype.chunk = function(arr, chunkSize) {

--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -58,7 +58,7 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
 
   // put all currently accumulated counter metrics into an array
   var currentCounterMetrics = [];
-  var currentNamespace = "AwsCloudWatchStatsdBackend";
+  var namespace = "AwsCloudWatchStatsdBackend";
   for (key in counters) {
     if (key.indexOf('statsd.') == 0)
       continue;
@@ -81,18 +81,20 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
   }
 
   // send off the array (instead of one at a time)
-  this.cloudwatch.putMetricData({
-    MetricData: currentCounterMetrics,
-    Namespace: namespace
-  }, function(err, data) {
-    if (err) {
-      // log an error
-      console.log(util.inspect(err));
-    } else {
-      // Success
-      // console.log(util.inspect(data));
-    }
-  });
+  if (currentCounterMetrics.length > 0) {
+    this.cloudwatch.putMetricData({
+      MetricData: currentCounterMetrics,
+      Namespace: namespace
+    }, function(err, data) {
+      if (err) {
+        // log an error
+        console.log(util.inspect(err));
+      } else {
+        // Success
+        // console.log(util.inspect(data));
+      }
+    });
+  }
 
   // put all currently accumulated timer metrics into an array
   var currentTimerMetrics = [];
@@ -146,18 +148,20 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
   }
 
   // send off the array (instead of one at a time)  
-  this.cloudwatch.putMetricData({
-    MetricData: currentTimerMetrics,
-    Namespace: namespace
-  }, function(err, data) {
-    if (err) {
-      // log an error
-      console.log(util.inspect(err));
-    } else {
-      // Success
-      // console.log(util.inspect(data));
-    }
-  });
+  if (currentTimerMetrics.length > 0) {
+    this.cloudwatch.putMetricData({
+      MetricData: currentTimerMetrics,
+      Namespace: namespace
+    }, function(err, data) {
+      if (err) {
+        // log an error
+        console.log(util.inspect(err));
+      } else {
+        // Success
+        // console.log(util.inspect(data));
+      }
+    });
+  }
 
   // put all currently accumulated gauge metrics into an array
   var currentGaugeMetrics = [];
@@ -181,18 +185,20 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
   }
 
   // send off the array (instead of one at a time)
-  this.cloudwatch.putMetricData({
-    MetricData: currentGaugeMetrics,
-    Namespace: namespace
-  }, function(err, data) {
-    if (err) {
-      // log an error
-      console.log(util.inspect(err));
-    } else {
-      // Success
-      // console.log(util.inspect(data));
-    }
-  });
+  if (currentGaugeMetrics.length > 0) {
+    this.cloudwatch.putMetricData({
+      MetricData: currentGaugeMetrics,
+      Namespace: namespace
+    }, function(err, data) {
+      if (err) {
+        // log an error
+        console.log(util.inspect(err));
+      } else {
+        // Success
+        // console.log(util.inspect(data));
+      }
+    });
+  }
 
   // put all currently accumulated set metrics into an array
   var currentSetMetrics = [];
@@ -215,18 +221,21 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
     });
   }
 
-  this.cloudwatch.putMetricData({
-    MetricData: currentSetMetrics,
-    Namespace: namespace
-  }, function(err, data) {
-    if (err) {
-      // log an error
-      console.log(util.inspect(err));
-    } else {
-      // Success
-      // console.log(util.inspect(data));
-    }
-  });
+  // send off the array (instead of one at a time)
+  if (currentSetMetrics.length > 0) {
+    this.cloudwatch.putMetricData({
+      MetricData: currentSetMetrics,
+      Namespace: namespace
+    }, function(err, data) {
+      if (err) {
+        // log an error
+        console.log(util.inspect(err));
+      } else {
+        // Success
+        // console.log(util.inspect(data));
+      }
+    });
+  }
 };
 
 exports.init = function(startupTime, config, events) {

--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -47,6 +47,16 @@ CloudwatchBackend.prototype.processKey = function(key) {
   };
 };
 
+CloudwatchBackend.prototype.isBlacklisted = function(key) {
+
+  if (this.config.blacklist && this.config.blacklist.length > 0 && this.config.blacklist.indexOf(key) !== -1) {
+    // console.log("Key (counter) " + key + " is blacklisted");
+    return true;
+  }
+
+  return false;
+};
+
 CloudwatchBackend.prototype.chunk = function(arr, chunkSize) {
 
   var groups = [],
@@ -103,6 +113,10 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
       continue;
     }
 
+    if (this.isBlacklisted(key)) {
+      continue;
+    }
+
     var names = this.config.processKeyForNamespace ? this.processKey(key) : {};
     namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
     var metricName = this.config.metricName || names.metricName || key;
@@ -124,6 +138,10 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
 
       if (this.config.whitelist && this.config.whitelist.length > 0 && this.config.whitelist.indexOf(key) == -1) {
         console.log("Key (counter) " + key + " not in whitelist");
+        continue;
+      }
+
+      if (this.isBlacklisted(key)) {
         continue;
       }
 
@@ -179,6 +197,10 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
       continue;
     }
 
+    if (this.isBlacklisted(key)) {
+      continue;
+    }
+
     var names = this.config.processKeyForNamespace ? this.processKey(key) : {};
     namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
     var metricName = this.config.metricName || names.metricName || key;
@@ -199,6 +221,10 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
 
     if (this.config.whitelist && this.config.whitelist.length > 0 && this.config.whitelist.indexOf(key) == -1) {
       console.log("Key (counter) " + key + " not in whitelist");
+      continue;
+    }
+
+    if (this.isBlacklisted(key)) {
       continue;
     }
 

--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -1,7 +1,7 @@
 var util = require('util');
 var AWS = require('aws-sdk');
 
-function CloudwatchBackend(startupTime, config, emitter){
+function CloudwatchBackend(startupTime, config, emitter) {
   var self = this;
 
   this.config = config || {};
@@ -13,22 +13,22 @@ function CloudwatchBackend(startupTime, config, emitter){
   }
 
   // if iamRole is set attempt to fetch credentials from the Metadata Service
-  if(this.config.iamRole) {
+  if (this.config.iamRole) {
     if (this.config.iamRole == 'any') {
       // If the iamRole is set to any, then attempt to fetch any available credentials
       ms = new AWS.EC2MetadataCredentials();
       ms.refresh(function(err) {
-        if(err) { console.log('Failed to fetch IAM role credentials: '+err); }
+        if (err) { console.log('Failed to fetch IAM role credentials: ' + err); }
         self.config.credentials = ms;
         setEmitter();
       });
     } else {
       // however if it's set to specify a role, query it specifically.
       ms = new AWS.MetadataService();
-      ms.request('/latest/meta-data/iam/security-credentials/'+this.config.iamRole, function(err, rdata) {
+      ms.request('/latest/meta-data/iam/security-credentials/' + this.config.iamRole, function(err, rdata) {
         var data = JSON.parse(rdata);
 
-        if(err) { console.log('Failed to fetch IAM role credentials: '+err); }
+        if (err) { console.log('Failed to fetch IAM role credentials: ' + err); }
         self.config.credentials = new AWS.Credentials(data.AccessKeyId, data.SecretAccessKey, data.Token);
         setEmitter();
       });
@@ -39,67 +39,80 @@ function CloudwatchBackend(startupTime, config, emitter){
 };
 
 CloudwatchBackend.prototype.processKey = function(key) {
-	var parts = key.split(/[\.\/-]/);
+  var parts = key.split(/[\.\/-]/);
 
-	return {
-		metricName: parts[parts.length-1],
-		namespace: parts.length > 1 ? parts.splice(0, parts.length-1).join("/") : null
-	};
-}
+  return {
+    metricName: parts[parts.length - 1],
+    namespace: parts.length > 1 ? parts.splice(0, parts.length - 1).join("/") : null
+  };
+};
 
 CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
 
-  console.log('Flushing metrics at ' + new Date(timestamp*1000).toISOString());
+  console.log('Flushing metrics at ' + new Date(timestamp * 1000).toISOString());
 
   var counters = metrics.counters;
   var gauges = metrics.gauges;
   var timers = metrics.timers;
   var sets = metrics.sets;
 
+  // put all currently accumulated counter metrics into an array
+  var currentCounterMetrics = [];
   for (key in counters) {
-	  if (key.indexOf('statsd.') == 0)
-		  continue;
+    if (key.indexOf('statsd.') == 0)
+      continue;
 
-        if(this.config.whitelist && this.config.whitelist.length >0 && this.config.whitelist.indexOf(key) == -1) {
-                console.log("Key (counter) "+key+" not in whitelist");
-                continue;
-        }
-	 
+    if (this.config.whitelist && this.config.whitelist.length > 0 && this.config.whitelist.indexOf(key) == -1) {
+      console.log("Key (counter) " + key + " not in whitelist");
+      continue;
+    }
+
     var names = this.config.processKeyForNamespace ? this.processKey(key) : {};
     var namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
     var metricName = this.config.metricName || names.metricName || key;
 
-    this.cloudwatch.putMetricData({
-      MetricData : [{
-                     MetricName : metricName,
-      Unit : 'Count',
-      Timestamp: new Date(timestamp*1000).toISOString(),
-      Value : counters[key]
-                   }],
-      Namespace  : namespace
-    },
-    function(err, data) {
-      console.log(util.inspect(err));
-      console.log(util.inspect(data));
+    currentCounterMetrics.push({
+      MetricName: metricName,
+      Unit: 'Count',
+      Timestamp: new Date(timestamp * 1000).toISOString(),
+      Value: counters[key]
     });
   }
 
+  // send off the array (instead of one at a time)
+  this.cloudwatch.putMetricData({
+    MetricData: currentCounterMetrics,
+    Namespace: namespace
+  }, function(err, data) {
+    if (err) {
+      // log an error
+      console.log(util.inspect(err));
+    } else {
+      // Success
+      // console.log(util.inspect(data));
+    }
+  });
+
+  // put all currently accumulated timer metrics into an array
+  var currentTimerMetrics = [];
   for (key in timers) {
     if (timers[key].length > 0) {
 
-        if(this.config.whitelist && this.config.whitelist.length >0 && this.config.whitelist.indexOf(key) == -1) {
-                console.log("Key (counter) "+key+" not in whitelist");
-                continue;
-        }
+      if (this.config.whitelist && this.config.whitelist.length > 0 && this.config.whitelist.indexOf(key) == -1) {
+        console.log("Key (counter) " + key + " not in whitelist");
+        continue;
+      }
 
-      var values = timers[key].sort(function (a,b) { return a-b; });
+      var values = timers[key].sort(function(a, b) {
+        return a - b;
+      });
       var count = values.length;
       var min = values[0];
       var max = values[count - 1];
 
       var cumulativeValues = [min];
       for (var i = 1; i < count; i++) {
-        cumulativeValues.push(values[i] + cumulativeValues[i-1]);
+        cumulativeValues.push(values[i] + cumulativeValues[i - 1]);
       }
 
       var sum = min;
@@ -110,87 +123,109 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
 
       var key2;
 
-      sum = cumulativeValues[count-1];
+      sum = cumulativeValues[count - 1];
       mean = sum / count;
 
       var names = this.config.processKeyForNamespace ? this.processKey(key) : {};
       var namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
       var metricName = this.config.metricName || names.metricName || key;
 
-      this.cloudwatch.putMetricData({
-        MetricData : [{
-          MetricName : metricName,
-          Unit : 'Milliseconds',
-          Timestamp: new Date(timestamp*1000).toISOString(),
-          StatisticValues: {
-            Minimum: min,
-            Maximum: max,
-            Sum: sum,
-            SampleCount: count
-          }
-                     }],
-        Namespace  : namespace
-      },
-      function(err, data) {
-        console.log(util.inspect(err));
-        console.log(util.inspect(data));
+      currentTimerMetrics.push({
+        MetricName: metricName,
+        Unit: 'Milliseconds',
+        Timestamp: new Date(timestamp * 1000).toISOString(),
+        StatisticValues: {
+          Minimum: min,
+          Maximum: max,
+          Sum: sum,
+          SampleCount: count
+        }
       });
-   	}
+    }
   }
 
+  // send off the array (instead of one at a time)  
+  this.cloudwatch.putMetricData({
+    MetricData: currentTimerMetrics,
+    Namespace: namespace
+  }, function(err, data) {
+    if (err) {
+      // log an error
+      console.log(util.inspect(err));
+    } else {
+      // Success
+      // console.log(util.inspect(data));
+    }
+  });
+
+  // put all currently accumulated gauge metrics into an array
+  var currentGaugeMetrics = [];
   for (key in gauges) {
 
-        if(this.config.whitelist && this.config.whitelist.length >0 && this.config.whitelist.indexOf(key) == -1) {
-                console.log("Key (counter) "+key+" not in whitelist");
-                continue;
-        }
+    if (this.config.whitelist && this.config.whitelist.length > 0 && this.config.whitelist.indexOf(key) == -1) {
+      console.log("Key (counter) " + key + " not in whitelist");
+      continue;
+    }
 
     var names = this.config.processKeyForNamespace ? this.processKey(key) : {};
     var namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
     var metricName = this.config.metricName || names.metricName || key;
 
-    this.cloudwatch.putMetricData({
-      MetricData : [{
-                     MetricName : metricName,
-      Unit : 'None',
-      Timestamp: new Date(timestamp*1000).toISOString(),
-      Value : gauges[key]
-                   }],
-      Namespace  : namespace
-    },
-
-    function(err, data) {
-      console.log(util.inspect(err));
-      console.log(util.inspect(data));
+    currentGaugeMetrics.push({
+      MetricName: metricName,
+      Unit: 'None',
+      Timestamp: new Date(timestamp * 1000).toISOString(),
+      Value: gauges[key]
     });
   }
 
+  // send off the array (instead of one at a time)
+  this.cloudwatch.putMetricData({
+    MetricData: currentGaugeMetrics,
+    Namespace: namespace
+  }, function(err, data) {
+    if (err) {
+      // log an error
+      console.log(util.inspect(err));
+    } else {
+      // Success
+      // console.log(util.inspect(data));
+    }
+  });
+
+  // put all currently accumulated set metrics into an array
+  var currentSetMetrics = [];
   for (key in sets) {
 
-        if(this.config.whitelist && this.config.whitelist.length >0 && this.config.whitelist.indexOf(key) == -1) {
-                console.log("Key (counter) "+key+" not in whitelist");
-                continue;
-        }
+    if (this.config.whitelist && this.config.whitelist.length > 0 && this.config.whitelist.indexOf(key) == -1) {
+      console.log("Key (counter) " + key + " not in whitelist");
+      continue;
+    }
 
     var names = this.config.processKeyForNamespace ? this.processKey(key) : {};
     var namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
     var metricName = this.config.metricName || names.metricName || key;
 
-    this.cloudwatch.putMetricData({
-      MetricData : [{
-                     MetricName : metricName,
-      Unit : 'None',
-      Timestamp: new Date(timestamp*1000).toISOString(),
-      Value : sets[key].values().length
-                   }],
-      Namespace  : namespace
-    },
-
-    function(err, data) {
-      console.log(util.inspect(err));
-      console.log(util.inspect(data));
+    currentSetMetrics.push({
+      MetricName: metricName,
+      Unit: 'None',
+      Timestamp: new Date(timestamp * 1000).toISOString(),
+      Value: sets[key].values().length
     });
   }
+
+  this.cloudwatch.putMetricData({
+    MetricData: currentSetMetrics,
+    Namespace: namespace
+  }, function(err, data) {
+    if (err) {
+      // log an error
+      console.log(util.inspect(err));
+    } else {
+      // Success
+      // console.log(util.inspect(data));
+    }
+  });
 };
 
 exports.init = function(startupTime, config, events) {


### PR DESCRIPTION
While using the backend, we noticed that it was logging to /var/log/statsd.log (a lot) and that was filling up one of our disk partitions.  Also, on busy servers, sending one metric at a time can incur significant bandwidth costs.  In addition, we found it useful to have a blacklist in addition to a whitelist set of metrics (whitelist always takes precedence)

This PR provides the following changes:
  - chunk up into batches of 20 (instead of default one at a time, cuts down PUT metric bandwidth by potentially 1/20). Note that Cloudwatch only allows a max of 20 at a time (bummer)
  - add blacklisted metrics via a "blacklist" attribute (value is an array of strings).  Looks for substring occurances instead of an exact match
  - only log errors in sending

In addition, we found that changing the default statsd flush interval from 10s to 30s or 1m was also a better option (given that Cloudwatch is not near-real time anyways).

Also, we found that sending statsd log output to /dev/null (or disabling it) was an OK option