### PR TITLE
Add debug option that can be used to turn off whitelist log messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ Using cloudwatch will incur a cost for each metric sent. In order to control you
             accessKeyId: 'YOUR_ACCESS_KEY_ID', 
             secretAccessKey: 'YOUR_SECRET_ACCESS_KEY', 
             region: 'YOUR_REGION',
-            whitelist: ['YOUR_FULL_METRIC_NAME']
+            whitelist: ['YOUR_FULL_METRIC_NAME'],
+            debug: false
         }
     }
 

--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -60,11 +60,11 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
 	  if (key.indexOf('statsd.') == 0)
 		  continue;
 
-        if(this.config.whitelist && this.config.whitelist.length >0 && this.config.whitelist.indexOf(key) == -1) {
-                console.log("Key (counter) "+key+" not in whitelist");
-                continue;
-        }
-	 
+    if(this.config.whitelist && this.config.whitelist.length >0 && this.config.whitelist.indexOf(key) == -1) {
+      if (this.config.debug !== false) console.log("Key (counter) "+key+" not in whitelist");
+      continue;
+    }
+
     var names = this.config.processKeyForNamespace ? this.processKey(key) : {};
     var namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
     var metricName = this.config.metricName || names.metricName || key;
@@ -87,10 +87,10 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
   for (key in timers) {
     if (timers[key].length > 0) {
 
-        if(this.config.whitelist && this.config.whitelist.length >0 && this.config.whitelist.indexOf(key) == -1) {
-                console.log("Key (counter) "+key+" not in whitelist");
-                continue;
-        }
+      if(this.config.whitelist && this.config.whitelist.length >0 && this.config.whitelist.indexOf(key) == -1) {
+        if (this.config.debug !== false) console.log("Key (counter) "+key+" not in whitelist");
+        continue;
+      }
 
       var values = timers[key].sort(function (a,b) { return a-b; });
       var count = values.length;
@@ -140,10 +140,10 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
 
   for (key in gauges) {
 
-        if(this.config.whitelist && this.config.whitelist.length >0 && this.config.whitelist.indexOf(key) == -1) {
-                console.log("Key (counter) "+key+" not in whitelist");
-                continue;
-        }
+    if(this.config.whitelist && this.config.whitelist.length >0 && this.config.whitelist.indexOf(key) == -1) {
+      if (this.config.debug !== false) console.log("Key (counter) "+key+" not in whitelist");
+      continue;
+    }
 
     var names = this.config.processKeyForNamespace ? this.processKey(key) : {};
     var namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
@@ -167,10 +167,10 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
 
   for (key in sets) {
 
-        if(this.config.whitelist && this.config.whitelist.length >0 && this.config.whitelist.indexOf(key) == -1) {
-                console.log("Key (counter) "+key+" not in whitelist");
-                continue;
-        }
+    if(this.config.whitelist && this.config.whitelist.length >0 && this.config.whitelist.indexOf(key) == -1) {
+      if (this.config.debug !== false) console.log("Key (counter) "+key+" not in whitelist");
+      continue;
+    }
 
     var names = this.config.processKeyForNamespace ? this.processKey(key) : {};
     var namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";


### PR DESCRIPTION
If you use the whitelist option, it generates a log line everytime the
whitelist excludes a metric.   This can generate thousands of log
messages every 10 seconds, flooding your journal.

Add the configuration variable 'debug', which when explicitly set to
false, turns off these messages.