### PR TITLE
support mapNameToDimensionsFn map

### DIFF
--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -55,6 +55,7 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
   var gauges = metrics.gauges;
   var timers = metrics.timers;
   var sets = metrics.sets;
+  var mapFn = this.config.mapNameToDimensionsFn;
 
   for (key in counters) {
 	  if (key.indexOf('statsd.') == 0)
@@ -68,10 +69,22 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
     var names = this.config.processKeyForNamespace ? this.processKey(key) : {};
     var namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
     var metricName = this.config.metricName || names.metricName || key;
+    var metricDimensions = [];
+    var mapRes;
+
+    if (mapFn) {
+        mapRes = mapFn(metricName, "count");
+        if (!mapRes) // skip this
+            continue;
+
+        metricName = mapRes.metricName;
+        metricDimensions = mapRes.metricDimensions;
+    }
 
     this.cloudwatch.putMetricData({
       MetricData : [{
-                     MetricName : metricName,
+      MetricName : metricName,
+      Dimensions: metricDimensions,
       Unit : 'Count',
       Timestamp: new Date(timestamp*1000).toISOString(),
       Value : counters[key]
@@ -105,7 +118,7 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
       var sum = min;
       var mean = min;
       var maxAtThreshold = max;
-
+      var metricDimensions = [];
       var message = "";
 
       var key2;
@@ -117,9 +130,20 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
       var namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
       var metricName = this.config.metricName || names.metricName || key;
 
+      if (mapFn) {
+        mapRes = mapFn(metricName, "timer");
+
+        if (!mapRes) // skip this
+          continue;
+
+        metricName = mapRes.metricName;
+        metricDimensions = mapRes.metricDimensions;
+      }
+
       this.cloudwatch.putMetricData({
         MetricData : [{
           MetricName : metricName,
+          Dimensions: metricDimensions,
           Unit : 'Milliseconds',
           Timestamp: new Date(timestamp*1000).toISOString(),
           StatisticValues: {
@@ -148,10 +172,21 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
     var names = this.config.processKeyForNamespace ? this.processKey(key) : {};
     var namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
     var metricName = this.config.metricName || names.metricName || key;
+    var metricDimensions = [];
+
+    if (mapFn) {
+        mapRes = mapFn(metricName, "gauge");
+        if (!mapRes) // skip this
+          continue;
+
+      metricName = mapRes.metricName;
+      metricDimensions = mapRes.metricDimensions;
+    }
 
     this.cloudwatch.putMetricData({
       MetricData : [{
-                     MetricName : metricName,
+      MetricName : metricName,
+      Dimensions: metricDimensions,
       Unit : 'None',
       Timestamp: new Date(timestamp*1000).toISOString(),
       Value : gauges[key]
@@ -175,10 +210,21 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
     var names = this.config.processKeyForNamespace ? this.processKey(key) : {};
     var namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
     var metricName = this.config.metricName || names.metricName || key;
+    var metricDimensions = [];
+
+    if (mapFn) {
+      mapRes = mapFn(metricName, "set");
+      if (!mapRes) // skip this
+        continue;
+
+      metricName = mapRes.metricName;
+      metricDimensions = mapRes.metricDimensions;
+    }
 
     this.cloudwatch.putMetricData({
       MetricData : [{
-                     MetricName : metricName,
+      MetricName : metricName,
+      Dimensions: metricDimensions,
       Unit : 'None',
       Timestamp: new Date(timestamp*1000).toISOString(),
       Value : sets[key].values().length


### PR DESCRIPTION
This is useful to define CloudWatch dimensions from the metric name.

I need this functionality to map graphite-like names to CW. This approach is pretty flexible, although I know that defining a function in a configuration file feels awkward. Speaking of flexibility, I wonder if it would make the map function to define the namespace as well.

Please let me know if you consider this approach acceptable, and/or if you have alternatives to propose.

Thank you.