### PR TITLE
Remove metadata query when role === "any"

### DIFF
--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -13,26 +13,16 @@ function CloudwatchBackend(startupTime, config, emitter) {
   }
 
   // if iamRole is set attempt to fetch credentials from the Metadata Service
-  if (this.config.iamRole) {
-    if (this.config.iamRole == 'any') {
-      // If the iamRole is set to any, then attempt to fetch any available credentials
-      ms = new AWS.EC2MetadataCredentials();
-      ms.refresh(function(err) {
-        if (err) { console.log('Failed to fetch IAM role credentials: ' + err); }
-        self.config.credentials = ms;
-        setEmitter();
-      });
-    } else {
-      // however if it's set to specify a role, query it specifically.
-      ms = new AWS.MetadataService();
-      ms.request('/latest/meta-data/iam/security-credentials/' + this.config.iamRole, function(err, rdata) {
-        var data = JSON.parse(rdata);
+  if (this.config.iamRole && this.config.iamRole !== 'any') {
+    // if it's set to specify a role, query it specifically.
+    ms = new AWS.MetadataService();
+    ms.request('/latest/meta-data/iam/security-credentials/' + this.config.iamRole, function(err, rdata) {
+      var data = JSON.parse(rdata);
 
-        if (err) { console.log('Failed to fetch IAM role credentials: ' + err); }
-        self.config.credentials = new AWS.Credentials(data.AccessKeyId, data.SecretAccessKey, data.Token);
-        setEmitter();
-      });
-    }
+      if (err) { console.log('Failed to fetch IAM role credentials: ' + err); }
+      self.config.credentials = new AWS.Credentials(data.AccessKeyId, data.SecretAccessKey, data.Token);
+      setEmitter();
+    });
   } else {
     setEmitter();
   }


### PR DESCRIPTION
if role is set to "any", we don't need to query the metadata service explicitly.

node aws-sdk will already use the correct credentials by itself