### PR TITLE
update package.json aws-sdk to ~2.82

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "author": "Martin Camitz<martin.camitz@simpletask.se>",
   "description": "A backend for StatsD to emit stats to Amazon's AWS CloudWatch.",
   "name": "aws-cloudwatch-statsd-backend",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "lib/aws-cloudwatch-statsd-backend.js",
   "dependencies": {
-    "aws-sdk": "~2.0.15"
+    "aws-sdk": "~2.82"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
Update the aws-sdk library to allow use in AWS regions which require v4 API call signing, such as eu-central-1.