### PR TITLE
Update example regions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The following demonstrates the minimum config for the CloudWatch backend.
 
 The access keys can be you personal credentials to AWS but it is highly recommended to create an ad hoc user via Amazon's IAM service and use those credentials.
 
-The region is for example EU_WEST_1 or US_EAST_1.
+The region is for example `eu-west-1` or `us-east-1`.
 
 The above will create a metric with the default namespace, AwsCloudWatchStatsdBackend, and send an http request to CloudWatch via awssum.
 


### PR DESCRIPTION
As of https://github.com/camitz/aws-cloudwatch-statsd-backend/commit/8bdb1669c22da7044af87d8057821c2b042c10e9 the way in which regions are used has changed from `EU_WEST_1` to `eu-west-1`.