### PR TITLE
Update for multi-namespace

### DIFF
--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -113,7 +113,7 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
   var sets = metrics.sets;
 
   // put all currently accumulated counter metrics into an array
-  var currentCounterMetrics = [];
+  var currentNamespaces = {};
   var namespace = "AwsCloudWatchStatsdBackend";
   for (key in counters) {
     if (key.indexOf('statsd.') == 0)
@@ -126,19 +126,21 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
     var names = this.config.processKeyForNamespace ? this.processKey(key) : {};
     namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
     var metricName = this.config.metricName || names.metricName || key;
+    if (!currentNamespaces.hasOwnProperty(namespace)) currentNamespaces[namespace] = []
 
-    currentCounterMetrics.push({
+    currentNamespaces[namespace].push({
       MetricName: metricName,
       Unit: 'Count',
       Timestamp: new Date(timestamp * 1000).toISOString(),
       Value: counters[key]
     });
   }
-
-  this.batchSend(currentCounterMetrics, namespace);
+  for (namespace in currentNamespaces){
+    this.batchSend(currentNamespaces[namespace], namespace);
+  }
 
   // put all currently accumulated timer metrics into an array
-  var currentTimerMetrics = [];
+  currentNamespaces = {};
   for (key in timers) {
     if (timers[key].length > 0) {
 
@@ -172,8 +174,9 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
       var names = this.config.processKeyForNamespace ? this.processKey(key) : {};
       namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
       var metricName = this.config.metricName || names.metricName || key;
+      if (!currentNamespaces.hasOwnProperty(namespace)) currentNamespaces[namespace] = []
 
-      currentTimerMetrics.push({
+      currentNamespaces[namespace].push({
         MetricName: metricName,
         Unit: 'Milliseconds',
         Timestamp: new Date(timestamp * 1000).toISOString(),
@@ -187,10 +190,12 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
     }
   }
 
-  this.batchSend(currentTimerMetrics, namespace);
+  for (namespace in currentNamespaces){
+    this.batchSend(currentNamespaces[namespace], namespace);
+  }
 
   // put all currently accumulated gauge metrics into an array
-  var currentGaugeMetrics = [];
+  currentNamespaces = {};
   for (key in gauges) {
 
     if (this.isBlacklisted(key)) {
@@ -200,8 +205,9 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
     var names = this.config.processKeyForNamespace ? this.processKey(key) : {};
     namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
     var metricName = this.config.metricName || names.metricName || key;
+    if (!currentNamespaces.hasOwnProperty(namespace)) currentNamespaces[namespace] = []
 
-    currentGaugeMetrics.push({
+    currentNamespaces[namespace].push({
       MetricName: metricName,
       Unit: 'None',
       Timestamp: new Date(timestamp * 1000).toISOString(),
@@ -209,10 +215,12 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
     });
   }
 
-  this.batchSend(currentGaugeMetrics, namespace);
+  for (namespace in currentNamespaces){
+    this.batchSend(currentNamespaces[namespace], namespace);
+  }
 
   // put all currently accumulated set metrics into an array
-  var currentSetMetrics = [];
+  currentNamespaces = {};
   for (key in sets) {
 
     if (this.isBlacklisted(key)) {
@@ -222,8 +230,9 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
     var names = this.config.processKeyForNamespace ? this.processKey(key) : {};
     namespace = this.config.namespace || names.namespace || "AwsCloudWatchStatsdBackend";
     var metricName = this.config.metricName || names.metricName || key;
+    if (!currentNamespaces.hasOwnProperty(namespace)) currentNamespaces[namespace] = []
 
-    currentSetMetrics.push({
+    currentNamespaces[namespace].push({
       MetricName: metricName,
       Unit: 'None',
       Timestamp: new Date(timestamp * 1000).toISOString(),
@@ -231,7 +240,9 @@ CloudwatchBackend.prototype.flush = function(timestamp, metrics) {
     });
   }
 
-  this.batchSend(currentSetMetrics, namespace);
+  for (namespace in currentNamespaces){
+    this.batchSend(currentNamespaces[namespace], namespace);
+  }
 };
 
 exports.init = function(startupTime, config, events) {


### PR DESCRIPTION
Issue: 
When processKeyForNames:true
- group.division.env.1:1|c
- group.division.env.2:1|c
Result: count 2 against group.division.env.1.
Desired: count 1 against both group.division.env.1 and group.division.env.2

Pull request contains a possible solution to honor multiple namespaces.
