### PR TITLE
Increase chunk group to 1000

### DIFF
--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -1,6 +1,15 @@
 var util = require('util');
 var AWS = require('aws-sdk');
 
+// PutMetricData Limits;
+// - Each request is limited to no more than 1000 different metrics
+// - Each PutMetricData request is limited to 1 MB
+// - Each metric can contain up to 150 values
+// WARNING: A the moment only the only limit implemented is 'metrics_group_chunk_size'
+//
+// Reference:
+// https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricData.html
+
 const metrics_group_chunk_size = 1000
 
 function CloudwatchBackend(startupTime, config, emitter) {

--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -85,8 +85,8 @@ CloudwatchBackend.prototype.batchSend = function(currentMetricsBatch, namespace)
   // send off the array (instead of one at a time)
   if (currentMetricsBatch.length > 0) {
 
-    // Chunk into groups of 20
-    var chunkedGroups = this.chunk(currentMetricsBatch, 20);
+    // Chunk into groups of 'cloudwatch_metrics_chunk_size'
+    var chunkedGroups = this.chunk(currentMetricsBatch, cloudwatch_metrics_chunk_size);
 
     for (var i = 0, len = chunkedGroups.length; i < len; i++) {
       this.cloudwatch.putMetricData({

--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -1,7 +1,7 @@
 var util = require('util');
 var AWS = require('aws-sdk');
 
-const cloudwatch_metrics_chunk_size = 1000
+const metrics_group_chunk_size = 1000
 
 function CloudwatchBackend(startupTime, config, emitter) {
   var self = this;
@@ -85,8 +85,8 @@ CloudwatchBackend.prototype.batchSend = function(currentMetricsBatch, namespace)
   // send off the array (instead of one at a time)
   if (currentMetricsBatch.length > 0) {
 
-    // Chunk into groups of 'cloudwatch_metrics_chunk_size'
-    var chunkedGroups = this.chunk(currentMetricsBatch, cloudwatch_metrics_chunk_size);
+    // Chunk into groups of 'metrics_group_chunk_size'
+    var chunkedGroups = this.chunk(currentMetricsBatch, metrics_group_chunk_size);
 
     for (var i = 0, len = chunkedGroups.length; i < len; i++) {
       this.cloudwatch.putMetricData({

--- a/lib/aws-cloudwatch-statsd-backend.js
+++ b/lib/aws-cloudwatch-statsd-backend.js
@@ -1,6 +1,8 @@
 var util = require('util');
 var AWS = require('aws-sdk');
 
+const cloudwatch_metrics_chunk_size = 1000
+
 function CloudwatchBackend(startupTime, config, emitter) {
   var self = this;
 


### PR DESCRIPTION
In this PR:
- Increase the chunk_size limit from 20 to 1000 to reflect the new limits offered to us by AWS
- Define the limit as a constant
- Add comment regarding the limits